### PR TITLE
Add .travis.yml to run builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "node"
+install:
+  - npm install
+script:
+  - npm test


### PR DESCRIPTION
Travis CI is a continous integration service that is free for open source projects.
I added a .travis.yml that runs npm install and npm test on Travis CI.

Example: https://travis-ci.org/verzola/spalatum

It is possible to add a lot of different things as well:
- Running builds with different versions of node
- Deploy docs on GitHub pages
- Generate tags
- Send notifications

It is necessary that a member of the Catho organization signup on Travis CI and enable the integration.