### PR TITLE
Adjusting license to a valid SPDX license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fragments"
   ],
   "author": "Catho Online",
-  "license": "GPL-3.0-only",
+  "license": "GPL-3.0",
   "dependencies": {
     "bunyan": "^1.8.12",
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
Both licenses code GPL-3.0 and GPL-3.0-only do reference to the license GNU General Public License v3.0 only, but NPM do not recognize the GPL-3.0-only as a valid SPDX licnese:
- GPL-3.0: https://spdx.org/licenses/GPL-3.0.html
- GPL-3.0-only: https://spdx.org/licenses/GPL-3.0-only.html
